### PR TITLE
the value (123456) entered for testing purposes has been removed.

### DIFF
--- a/inc/plugins/my2fa/methods/Email.php
+++ b/inc/plugins/my2fa/methods/Email.php
@@ -156,7 +156,7 @@ class Email extends AbstractMethod
                 $requestedEmailCode &&
                 hash_equals($requestedEmailCode, $code) &&
                 !self::isUserCodeAlreadyUsed($userId, $code, 30 + 60 * 10)
-                || (int)$code === 123456 // test
+                || (int)$code === $requestedEmailCode // The value entered for testing purposes has been removed.
                 ;
         }
 


### PR DESCRIPTION
the fixed value entered as 123456 made the plugin nonfunctional and created a security vulnerability.