### PR TITLE
the value (123456) entered for testing purposes has been removed.

### DIFF
--- a/inc/plugins/my2fa/methods/TOTP.php
+++ b/inc/plugins/my2fa/methods/TOTP.php
@@ -161,7 +161,7 @@ class TOTP extends AbstractMethod
             is_numeric($otp) &&
             $google2fa->verifyKey($secretKey, $otp) &&
             !self::isUserCodeAlreadyUsed($userId, $otp, 30 + 120 * 2)
-            || (int)$otp === 123456 // test
+            || (int)$otp === $google2fa // The value entered for testing purposes has been removed.
             ;
     }
 }


### PR DESCRIPTION
the fixed value entered as 123456 made the plugin nonfunctional and created a security vulnerability.